### PR TITLE
Add City of London School

### DIFF
--- a/lib/domains/uk/org/cityoflondonschool.txt
+++ b/lib/domains/uk/org/cityoflondonschool.txt
@@ -1,0 +1,1 @@
+City of London School


### PR DESCRIPTION
There is no .org.uk
Assuming .uk.org is best fit